### PR TITLE
style(header): update logo styling and remove redundant id attributes

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -30,7 +30,7 @@
 		{{- $isExternal := ne $logoTarget "baseurl" -}}
 		{{- $targetUrl := cond (eq $logoTarget "baseurl") site.BaseURL (cond (eq $logoTarget "imgurl") $blogoLink $logoTarget) -}}
 		<a href="{{ $targetUrl }}" {{ if $isExternal }} target="_blank" {{ end }}>
-			<img id="blogo" alt="blogo" src="{{ $blogoLink }}"/>
+		    <img alt="blogo" src="{{ $blogoLink }}"/>
 		</a>
 	</div>
 	{{- end -}}

--- a/static/css/header.css
+++ b/static/css/header.css
@@ -61,7 +61,7 @@ div#header-bg {
 div#blogo {
     float: left;
 }
-img#blogo {
+div#blogo a img {
     margin: 0 auto;
     max-width: 144px;
     max-height: var(--header-height);


### PR DESCRIPTION
Fix #2 
- remove redundant `id` attribute for the blog logo in HTML
- target logo styling using a more specific CSS selector for consistency