### PR TITLE
Add configurable logo target option

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,8 @@
         blogo = "HugoAliceLogo.webp"
         title = "Hugo Alice"
         tagline = "so damn classic"
+        # "baseurl" or "imgurl" or "https://somewhere.com"
+        logoTarget = "baseurl"
 
     [params.footer]
         # Should display site generator (Hugo) and theme (Alice) 🥰

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -26,8 +26,11 @@
 	{{- with .Site.Params.Header.Blogo -}}
 	<div id="blogo">
 		{{- $blogoLink := (resources.Get .).RelPermalink -}}
-		<a href="{{ $blogoLink }}" target="_blank">
-		<img id="blogo" alt="blogo" src="{{ $blogoLink }}"/>
+		{{- $logoTarget := site.Params.Header.LogoTarget | default "baseurl" -}}
+		{{- $isExternal := ne $logoTarget "baseurl" -}}
+		{{- $targetUrl := cond (eq $logoTarget "baseurl") site.BaseURL (cond (eq $logoTarget "imgurl") $blogoLink $logoTarget) -}}
+		<a href="{{ $targetUrl }}" {{ if $isExternal }} target="_blank" {{ end }}>
+			<img id="blogo" alt="blogo" src="{{ $blogoLink }}"/>
 		</a>
 	</div>
 	{{- end -}}


### PR DESCRIPTION
Close #3 

- Support `LogoTarget` parameter to set logo link target dynamically
- Allow external, image URL, or base URL as the logo anchor destination