### PR TITLE
Add configurable postcard description display option

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -110,6 +110,9 @@
         # fancybox or glightbox
         vendor = 'fancybox'
 
+    [params.postcard]
+        showDescription = false
+
     # waline v3 comment system
     [params.waline]
         enable = false

--- a/layouts/partials/post-card.html
+++ b/layouts/partials/post-card.html
@@ -30,6 +30,9 @@
 			"metaItemSep" ""
 		) -}}
 		{{- partial "post-tldr.html" . -}}
+        {{- if site.Params.postcard.showDescription -}}
+            <p class="post-description">{{ .Description | markdownify | safeHTML }}</p>
+        {{- end -}}
 		<a class="post-read-more" href="{{ .Permalink }}">Read more >>></a>
 	</div>
 </div>


### PR DESCRIPTION
Close #8 

- Introduce `params.postcard.showDescription` to toggle post description visibility
- Render post description with markdown support if enabled

![image](https://github.com/user-attachments/assets/3d211e34-2b82-47af-8c7b-9ad467e2dd1c)
