### PR TITLE
Add code block render hooks for mermaid

### DIFF
--- a/docs/content/posts/authoring-shortcodes/index.md
+++ b/docs/content/posts/authoring-shortcodes/index.md
@@ -380,6 +380,24 @@ https://gohugo.io/content-management/diagrams/#goat-diagrams-ascii
 
 https://gohugo.io/content-management/diagrams/#mermaid-diagrams
 
+````md
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```
+````
+
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```
+
 ## Marks
 
 If this <mark>word</mark> has yellow background color and black font color on your screen,

--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,3 @@
+<pre class="mermaid">
+  {{ .Inner | htmlEscape | safeHTML }}
+</pre>


### PR DESCRIPTION
This pull request introduces support for rendering Mermaid diagrams in Hugo. The changes include updates to documentation and the addition of a new layout template for Mermaid code blocks.

- Added a new layout template `layouts/_default/_markup/render-codeblock-mermaid.html` to render Mermaid diagrams.
- Added examples of Mermaid diagrams to the `docs/content/posts/authoring-shortcodes/index.md` file to demonstrate how to use the feature.

Close #13.