### PR TITLE
Display logo only header on smaller screen

### DIFF
--- a/static/css/header.css
+++ b/static/css/header.css
@@ -214,6 +214,10 @@ div.hamburger-menu-item {
         margin: 0 0 0 1ch;
     }
 
+    header#header-with-toc div#bio {
+        display: none;
+    }
+
     nav#menu {
         display: none;
     }


### PR DESCRIPTION
This pull request includes a small change to the `static/css/header.css` file. The change hides the `div#bio` element within the `header#header-with-toc` section by setting its `display` property to `none`.

Close #5.

Before:
![image](https://github.com/user-attachments/assets/018ef7f7-cb61-4a74-9271-f5964e5dddc6)

After:
![image](https://github.com/user-attachments/assets/20c14288-49a5-4989-80c4-ca0666ef6fab)
