### PR TITLE
Make thumbnail link configurable

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -111,6 +111,8 @@
         vendor = 'fancybox'
 
     [params.postcard]
+        # "posturl" or "imgurl"
+        thumbTarget = "posturl"
         showDescription = false
 
     # waline v3 comment system

--- a/layouts/partials/post-card.html
+++ b/layouts/partials/post-card.html
@@ -15,8 +15,10 @@
 <div class="post-card {{ $layout }}">
 	{{- with $thumb -}}
     <div class="post-thumb-container">
-		<a class="post-thumb-anchor" href="{{ .RelPermalink }}">
-        <img class="post-thumb" src="{{ .RelPermalink }}" loading="lazy"/>
+		{{- $thumbLink := cond (eq site.Params.postcard.thumbTarget "posturl") $.RelPermalink .RelPermalink -}}
+		{{- $thumbTarget := cond (eq site.Params.postcard.thumbTarget "posturl") "" "_blank" -}}
+		<a class="post-thumb-anchor" href="{{ $thumbLink }}" target="{{ $thumbTarget }}">
+			<img alt="{{ $.Title }}" class="post-thumb" src="{{ .RelPermalink }}" loading="lazy"/>
 		</a>
 	</div>
 	{{- end -}}


### PR DESCRIPTION
This pull request introduces a configurable option for thumbnail link behavior in the postcard component. The changes allow users to specify whether thumbnail links should point to the post URL or an image URL and whether they should open in the same tab or a new tab.

Close #7.