### PR TITLE
Improve post-meta items display on smaller screens

### DIFF
--- a/static/css/post.css
+++ b/static/css/post.css
@@ -79,3 +79,27 @@ aside#sidenotes {
         box-shadow: none;
     }
 }
+
+@media screen and (max-width: 1080px) {
+
+    /* Make post-meta items display as block on small screens */
+    article .post-meta span.post-meta-item {
+        display: block;
+        margin: 0.5em 0;
+    }
+
+    /* Hide separators on small screens */
+    article .post-meta span:not(.post-meta-item) {
+        display: none;
+    }
+
+    /* Remove white-space: nowrap on small screens to allow wrapping */
+    article .post-meta {
+        white-space: normal;
+    }
+
+    /* Add space between post-date and lastmod-date on small screens */
+    article .post-meta .post-lastmod-date-icon {
+        margin-left: 1em;
+    }
+}


### PR DESCRIPTION
This pull request introduces responsive design improvements to the `post-meta` section in the single post page. The changes ensure better readability and usability on smaller screens.

- `post-meta-item` elements are displayed as block elements with spacing between them.
- Non-`post-meta-item` elements (separators) are hidden.
- The `white-space: nowrap` property is removed to allow text wrapping.

Before:
![image](https://github.com/user-attachments/assets/c3678569-c14d-47f9-a2f3-1a0da1266a2b)

After:
![image](https://github.com/user-attachments/assets/080c0222-2ec6-440b-b198-dfb11158d9c9)


Close #11.