### PR TITLE
RenderImage: Improve image render hook and lightbox integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public/
 .hugo_build.lock
+docs/resources/_gen/

--- a/config.toml
+++ b/config.toml
@@ -100,11 +100,18 @@
 
     [params.imgproc]
         enable = false
-        maxWidth = 1280
-        maxHeight = 1280
-        format = 'webp'
-        # 0-100
+        # Default format for processed images
+        format = "webp"
+        # 0-100, image quality for compressed formats
         quality = 75
+        # Image sizes for responsive images
+        sizes = ["420", "789", "1019", "1430", "2048"]
+        # Image resampling filter (Box, Lanczos, CatmullRom, MitchellNetravali, Linear, and NearestNeighbor)
+        resamplingFilter = "Lanczos"
+        # Default format for fallback images
+        fallbackFormat = "jpg"
+        # Default fallback image size
+        fallbackSize = "789"
 
     [params.lightbox]
         # fancybox or glightbox

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -105,11 +105,18 @@ themesDir = "../.."
 
     [params.imgproc]
         enable = false
-        maxWidth = 1280
-        maxHeight = 1280
-        format = 'webp'
-        # 0-100
+        # Default format for processed images
+        format = "webp"
+        # 0-100, image quality for compressed formats
         quality = 75
+        # Image sizes for responsive images
+        sizes = ["420", "789", "1019", "1430", "2048"]
+        # Image resampling filter (Box, Lanczos, CatmullRom, MitchellNetravali, Linear, and NearestNeighbor)
+        resamplingFilter = "Lanczos"
+        # Default format for fallback images
+        fallbackFormat = "jpg"
+        # Default fallback image size
+        fallbackSize = "789"
 
     [params.lightbox]
         # fancybox or glightbox

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,5 +1,11 @@
-{{- $image_sizes := slice "420" "789" "1019" "1430" "2048" -}}
-{{- $image_quality := "Lanczos" -}}
+{{- $enable_imgproc := site.Params.imgproc.enable | default false -}}
+{{- $image_sizes := site.Params.imgproc.sizes | default (slice "420" "789" "1019" "1430" "2048") -}}
+{{- $resampling_filter := site.Params.imgproc.resamplingFilter | default "Lanczos" -}}
+{{- $image_quality_value := site.Params.imgproc.quality | default 75 -}}
+{{- $quality_filter := print "q" $image_quality_value " " $resampling_filter -}}
+{{- $fallback_size := site.Params.imgproc.fallbackSize | default "789" -}}
+{{- $fallback_format := site.Params.imgproc.fallbackFormat | default "jpg" -}}
+{{- $image_format := site.Params.imgproc.format | default "webp" -}}
 {{- $alt := .Text -}}
 {{- $label := .Text -}}
 {{- $caption := "" -}}
@@ -20,7 +26,6 @@
     {{- $image_width = math.Floor (math.Div $image_width 2) -}}
     {{- $image_height = math.Floor (math.Div $image_height 2) -}}
   {{- end -}}
-  {{- $fallback_image := ($image.Resize (print "789x jpg " $image_quality)) -}}
   {{- $lightboxVendor := $.Page.Params.lightbox.vendor | default "none" }}
   <figure role="figure" aria-label="{{- $label | plainify -}}">
     <a href="{{- $image.RelPermalink -}}"
@@ -35,19 +40,20 @@
         title="{{- $label | plainify -}}"
         width="{{- $image_width -}}"
         height="{{- $image_height -}}"
-        {{- if (or (strings.HasSuffix $image ".gif") (strings.HasSuffix $image ".svg")) -}}
+        {{- if (or (strings.HasSuffix $image ".gif") (strings.HasSuffix $image ".svg") (not $enable_imgproc)) -}}
           src="{{- $image.RelPermalink -}}"
         {{- else -}}
+          {{- $fallback_image := ($image.Resize (print $fallback_size "x " $fallback_format " " $quality_filter)) -}}
           srcset="
             {{- if le $image.Width (index $image_sizes 0) }}
-              {{- with $image.Resize (print $image.Width "x webp " $image_quality) -}}
+              {{- with $image.Resize (print $image.Width "x " $image_format " " $quality_filter) -}}
                 {{- print .RelPermalink " " .Width "w, " -}}
               {{- end -}}
             {{- end -}}
             {{- with $image_sizes -}}
               {{- range $index, $size := . -}}
                 {{- if ge $image.Width $size -}}
-                  {{- with $image.Resize (print $size "x webp " $image_quality) -}}
+                  {{- with $image.Resize (print $size "x " $image_format " " $quality_filter) -}}
                     {{- print .RelPermalink " " $size "w, " -}}
                   {{- end -}}
                 {{- end -}}
@@ -55,7 +61,7 @@
             {{- end -}}
           "
           sizes="(min-width: 800px) 50vw, 100vw"
-          src="{{- $fallback_image.RelPermalink -}}"
+          src="{{- ($image.Resize (print $fallback_size "x " $fallback_format " " $quality_filter)).RelPermalink -}}"
         {{- end -}}
         {{- if strings.Contains $image "featured" -}}
           loading="eager"

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,27 +1,71 @@
-{{/* print .Attributes */}}
-
-{{/* FIXME: The default values should be configurable */}}
-{{- $width := .Attributes.width | default "100%" -}}
-{{- $height := .Attributes.height | default "auto" -}}
-{{- $classes := .Attributes.classes | default "center" }}
-
-{{- $sizeCSS := printf "width: %s; height: %s;" $width $height }}
-{{- $isFloat := strings.Contains $classes "float" -}}
-
-{{- $lightboxVendor := .Page.Params.lightbox.vendor | default "none" }}
-
-<figure {{ with $classes }}class="{{ . }}"{{ end }} {{ if $isFloat }}style="{{ $sizeCSS | safeCSS }}"{{ end }} >
-    <a href="{{ $.Destination | safeURL }}"
-    {{- if eq $lightboxVendor "fancybox" -}}
+{{- $image_sizes := slice "420" "789" "1019" "1430" "2048" -}}
+{{- $image_quality := "Lanczos" -}}
+{{- $alt := .Text -}}
+{{- $label := .Text -}}
+{{- $caption := "" -}}
+{{- if ne .Title "" -}}
+  {{- $caption = .Title | $.Page.RenderString -}}
+  {{- $label = $caption -}}
+{{- end -}}
+{{- $image := .Page.Resources.GetMatch .Destination -}}
+{{- if and (not $image) .Page.File -}}
+  {{- $image = resources.Get (path.Join .Page.File.Dir .Destination) -}}
+{{- else -}}
+  {{- $image := resources.Get $image -}}
+{{- end -}}
+{{- with $image -}}
+  {{- $image_width := $image.Width -}}
+  {{- $image_height := $image.Height -}}
+  {{- if strings.Contains $image "_2x" -}}
+    {{- $image_width = math.Floor (math.Div $image_width 2) -}}
+    {{- $image_height = math.Floor (math.Div $image_height 2) -}}
+  {{- end -}}
+  {{- $fallback_image := ($image.Resize (print "789x jpg " $image_quality)) -}}
+  {{- $lightboxVendor := $.Page.Params.lightbox.vendor | default "none" }}
+  <figure role="figure" aria-label="{{- $label | plainify -}}">
+    <a href="{{- $image.RelPermalink -}}"
+      {{- if eq $lightboxVendor "fancybox" -}}
         data-fancybox="gallery"
-    {{- else if eq $lightboxVendor "glightbox" -}}
+      {{- else if eq $lightboxVendor "glightbox" -}}
         class="glightbox" data-gallery="gallery"
-    {{- end -}}
+      {{- end -}}
     >
-    <img loading="lazy" src="{{ .Destination | safeURL }}" {{ if not $isFloat }}style="{{ $sizeCSS | safeCSS }}"{{ end }}
-        {{- with .PlainText }} alt="{{ . }}"{{ end -}}
-        {{- with .Title }} title="{{ . }}"{{ end -}}
-    >
+      <img
+        alt="{{- $caption | markdownify | plainify -}}"
+        title="{{- $label | plainify -}}"
+        width="{{- $image_width -}}"
+        height="{{- $image_height -}}"
+        {{- if (or (strings.HasSuffix $image ".gif") (strings.HasSuffix $image ".svg")) -}}
+          src="{{- $image.RelPermalink -}}"
+        {{- else -}}
+          srcset="
+            {{- if le $image.Width (index $image_sizes 0) }}
+              {{- with $image.Resize (print $image.Width "x webp " $image_quality) -}}
+                {{- print .RelPermalink " " .Width "w, " -}}
+              {{- end -}}
+            {{- end -}}
+            {{- with $image_sizes -}}
+              {{- range $index, $size := . -}}
+                {{- if ge $image.Width $size -}}
+                  {{- with $image.Resize (print $size "x webp " $image_quality) -}}
+                    {{- print .RelPermalink " " $size "w, " -}}
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+            {{- end -}}
+          "
+          sizes="(min-width: 800px) 50vw, 100vw"
+          src="{{- $fallback_image.RelPermalink -}}"
+        {{- end -}}
+        {{- if strings.Contains $image "featured" -}}
+          loading="eager"
+          decoding="sync"
+        {{- else -}}
+          decoding="async"
+          loading="lazy"
+        {{- end -}}
+      />
     </a>
-    {{- with .Title }}<figcaption>{{ . | markdownify }}</figcaption>{{ end -}}
-</figure>
+    <figcaption>{{- $caption | markdownify -}}</figcaption>
+  </figure>
+{{- end -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,4 +1,12 @@
 {{- define "main" -}}
+{{- $enable_imgproc := site.Params.imgproc.enable | default false -}}
+{{- $image_sizes := site.Params.imgproc.sizes | default (slice "420" "789" "1019" "1430" "2048") -}}
+{{- $resampling_filter := site.Params.imgproc.resamplingFilter | default "Lanczos" -}}
+{{- $image_quality_value := site.Params.imgproc.quality | default 75 -}}
+{{- $quality_filter := print "q" $image_quality_value " " $resampling_filter -}}
+{{- $fallback_size := site.Params.imgproc.fallbackSize | default "789" -}}
+{{- $fallback_format := site.Params.imgproc.fallbackFormat | default "jpg" -}}
+{{- $image_format := site.Params.imgproc.format | default "webp" -}}
 <main class="post">
 	<aside id="sidetoc">
 		{{- if .Params.toc.show -}}
@@ -22,18 +30,59 @@
 	<article>
 		{{- if .Params.featuredimage -}}
 		<figure class="featured-image">
-			{{- $link := "" -}}
 			{{- $src := .Params.featuredimage.src -}}
+			{{- $image := "" -}}
 			{{- if $src -}}
 				{{- if eq .Params.type "series" -}}
-					{{- $link = path.Join .Parent.RelPermalink $src -}}
+					{{- $link := path.Join .Parent.RelPermalink $src -}}
+					<a href="{{ $link }}" data-fancybox="featured-image">
+					<img class="featured-image" src="{{ $link }}" alt="{{ with .Params.featuredimage.title }}.{{ else }}featured-image{{ end }}" loading="eager" decoding="sync"/>
+					</a>
 				{{- else -}}
-					{{- $link = (.Page.Resources.GetMatch $src).RelPermalink -}}
+					{{- $image = .Page.Resources.GetMatch $src -}}
+					{{- with $image -}}
+						{{- $image_width := .Width -}}
+						{{- $image_height := .Height -}}
+						{{- if strings.Contains . "_2x" -}}
+							{{- $image_width = math.Floor (math.Div .Width 2) -}}
+							{{- $image_height = math.Floor (math.Div .Height 2) -}}
+						{{- end -}}
+						<a href="{{ .RelPermalink }}" data-fancybox="featured-image">
+							<img
+								class="featured-image"
+								alt="{{ with $.Params.featuredimage.title }}.{{ else }}featured-image{{ end }}"
+								width="{{- $image_width -}}"
+								height="{{- $image_height -}}"
+								{{- if (or (strings.HasSuffix . ".gif") (strings.HasSuffix . ".svg") (not $enable_imgproc)) -}}
+									src="{{- .RelPermalink -}}"
+								{{- else -}}
+									{{- $fallback_image := (.Resize (print $fallback_size "x " $fallback_format " " $quality_filter)) -}}
+									srcset="
+										{{- if le .Width (index $image_sizes 0) }}
+											{{- with .Resize (print .Width "x " $image_format " " $quality_filter) -}}
+												{{- print .RelPermalink " " .Width "w, " -}}
+											{{- end -}}
+										{{- end -}}
+										{{- with $image_sizes -}}
+											{{- range $index, $size := . -}}
+												{{- if ge $image.Width $size -}}
+													{{- with $image.Resize (print $size "x " $image_format " " $quality_filter) -}}
+														{{- print .RelPermalink " " $size "w, " -}}
+													{{- end -}}
+												{{- end -}}
+											{{- end -}}
+										{{- end -}}
+									"
+									sizes="(min-width: 800px) 50vw, 100vw"
+									src="{{- (.Resize (print $fallback_size "x " $fallback_format " " $quality_filter)).RelPermalink -}}"
+								{{- end -}}
+								loading="eager"
+								decoding="sync"
+							/>
+						</a>
+					{{- end -}}
 				{{- end -}}
 			{{- end -}}
-			<a href="{{ $link }}" data-fancybox="featured-image">
-			<img class="featured-image" src="{{ $link }}" alt="{{ with .Params.featuredimage.title }}.{{ else }}featured-image{{ end }}"/>
-			</a>
 			{{- with .Params.featuredimage.title -}}
 			<figcaption>{{ . | markdownify }}</figcaption>
 			{{- end -}}

--- a/layouts/partials/post-card.html
+++ b/layouts/partials/post-card.html
@@ -11,8 +11,14 @@
 		{{- $layout = "portrait" -}}
 	{{- end -}}
 {{- end -}}
-{{- $image_sizes := slice "420" "789" "1019" "1430" "2048" -}}
-{{- $image_quality := "Lanczos" -}}
+{{- $enable_imgproc := site.Params.imgproc.enable | default false -}}
+{{- $image_sizes := site.Params.imgproc.sizes | default (slice "420" "789" "1019" "1430" "2048") -}}
+{{- $resampling_filter := site.Params.imgproc.resamplingFilter | default "Lanczos" -}}
+{{- $image_quality_value := site.Params.imgproc.quality | default 75 -}}
+{{- $quality_filter := print "q" $image_quality_value " " $resampling_filter -}}
+{{- $fallback_size := site.Params.imgproc.fallbackSize | default "789" -}}
+{{- $fallback_format := site.Params.imgproc.fallbackFormat | default "jpg" -}}
+{{- $image_format := site.Params.imgproc.format | default "webp" -}}
 <div class="post-card-container">
 	<div class="post-card {{ $layout }}">
 		{{- with $thumb -}}
@@ -26,31 +32,31 @@
 					{{- $image_width = math.Floor (math.Div .Width 2) -}}
 					{{- $image_height = math.Floor (math.Div .Height 2) -}}
 				{{- end -}}
-				{{- $fallback_image := (.Resize (print "789x jpg " $image_quality)) -}}
 				<img
 					alt="{{ $.Title }}"
 					class="post-thumb"
 					width="{{- $image_width -}}"
 					height="{{- $image_height -}}"
-					{{- if (or (strings.HasSuffix . ".gif") (strings.HasSuffix . ".svg")) -}}
+					{{- if (or (strings.HasSuffix . ".gif") (strings.HasSuffix . ".svg") (not $enable_imgproc)) -}}
 						src="{{- .RelPermalink -}}"
 					{{- else -}}
+						{{- $fallback_image := (.Resize (print $fallback_size "x " $fallback_format " " $quality_filter)) -}}
 						srcset="
 							{{- if le .Width (index $image_sizes 0) }}
-								{{- with .Resize (print .Width "x webp " $image_quality) -}}
-									{{- print .RelPermalink " " .Width "w, " -}}
-								{{- end -}}
+							    {{- with .Resize (print .Width "x " $image_format " " $quality_filter) -}}
+							        {{- print .RelPermalink " " .Width "w, " -}}
+							    {{- end -}}
 							{{- end -}}
 							{{- range $index, $size := $image_sizes -}}
-								{{- if ge $thumb.Width $size -}}
-									{{- with $thumb.Resize (print $size "x webp " $image_quality) -}}
+							    {{- if ge $thumb.Width $size -}}
+							        {{- with $thumb.Resize (print $size "x " $image_format " " $quality_filter) -}}
 										{{- print .RelPermalink " " $size "w, " -}}
 									{{- end -}}
 								{{- end -}}
 							{{- end -}}
 						"
 						sizes="(min-width: 800px) 50vw, 100vw"
-						src="{{- $fallback_image.RelPermalink -}}"
+						src="{{- (.Resize (print $fallback_size "x " $fallback_format " " $quality_filter)).RelPermalink -}}"
 					{{- end -}}
 					loading="lazy"
 					decoding="async"

--- a/layouts/partials/post-card.html
+++ b/layouts/partials/post-card.html
@@ -11,31 +11,67 @@
 		{{- $layout = "portrait" -}}
 	{{- end -}}
 {{- end -}}
+{{- $image_sizes := slice "420" "789" "1019" "1430" "2048" -}}
+{{- $image_quality := "Lanczos" -}}
 <div class="post-card-container">
-<div class="post-card {{ $layout }}">
-	{{- with $thumb -}}
-    <div class="post-thumb-container">
-		{{- $thumbLink := cond (eq site.Params.postcard.thumbTarget "posturl") $.RelPermalink .RelPermalink -}}
-		{{- $thumbTarget := cond (eq site.Params.postcard.thumbTarget "posturl") "" "_blank" -}}
-		<a class="post-thumb-anchor" href="{{ $thumbLink }}" target="{{ $thumbTarget }}">
-			<img alt="{{ $.Title }}" class="post-thumb" src="{{ .RelPermalink }}" loading="lazy"/>
-		</a>
+	<div class="post-card {{ $layout }}">
+		{{- with $thumb -}}
+			<div class="post-thumb-container">
+			{{- $thumbLink := cond (eq site.Params.postcard.thumbTarget "posturl") $.RelPermalink .RelPermalink -}}
+			{{- $thumbTarget := cond (eq site.Params.postcard.thumbTarget "posturl") "" "_blank" -}}
+			<a class="post-thumb-anchor" href="{{ $thumbLink }}" target="{{ $thumbTarget }}">
+				{{- $image_width := .Width -}}
+				{{- $image_height := .Height -}}
+				{{- if strings.Contains . "_2x" -}}
+					{{- $image_width = math.Floor (math.Div .Width 2) -}}
+					{{- $image_height = math.Floor (math.Div .Height 2) -}}
+				{{- end -}}
+				{{- $fallback_image := (.Resize (print "789x jpg " $image_quality)) -}}
+				<img
+					alt="{{ $.Title }}"
+					class="post-thumb"
+					width="{{- $image_width -}}"
+					height="{{- $image_height -}}"
+					{{- if (or (strings.HasSuffix . ".gif") (strings.HasSuffix . ".svg")) -}}
+						src="{{- .RelPermalink -}}"
+					{{- else -}}
+						srcset="
+							{{- if le .Width (index $image_sizes 0) }}
+								{{- with .Resize (print .Width "x webp " $image_quality) -}}
+									{{- print .RelPermalink " " .Width "w, " -}}
+								{{- end -}}
+							{{- end -}}
+							{{- range $index, $size := $image_sizes -}}
+								{{- if ge $thumb.Width $size -}}
+									{{- with $thumb.Resize (print $size "x webp " $image_quality) -}}
+										{{- print .RelPermalink " " $size "w, " -}}
+									{{- end -}}
+								{{- end -}}
+							{{- end -}}
+						"
+						sizes="(min-width: 800px) 50vw, 100vw"
+						src="{{- $fallback_image.RelPermalink -}}"
+					{{- end -}}
+					loading="lazy"
+					decoding="async"
+				/>
+			</a>
+		</div>
+		{{- end -}}
+		<div class="post-card-content">
+			<h3 class="post-title">
+					<a href="{{ .RelPermalink }}">{{ .Title | markdownify | safeHTML }}</a>
+			</h3>
+			{{- partial "post-meta.html" (dict
+				"page" .
+				"metaItemTag" "div"
+				"metaItemSep" ""
+			) -}}
+			{{- partial "post-tldr.html" . -}}
+			{{- if site.Params.postcard.showDescription -}}
+					<p class="post-description">{{ .Description | markdownify | safeHTML }}</p>
+			{{- end -}}
+			<a class="post-read-more" href="{{ .Permalink }}">Read more >>></a>
+		</div>
 	</div>
-	{{- end -}}
-	<div class="post-card-content">
-        <h3 class="post-title">
-            <a href="{{ .RelPermalink }}">{{ .Title | markdownify | safeHTML }}</a>
-		</h3>
-        {{- partial "post-meta.html" (dict
-			"page" .
-			"metaItemTag" "div"
-			"metaItemSep" ""
-		) -}}
-		{{- partial "post-tldr.html" . -}}
-        {{- if site.Params.postcard.showDescription -}}
-            <p class="post-description">{{ .Description | markdownify | safeHTML }}</p>
-        {{- end -}}
-		<a class="post-read-more" href="{{ .Permalink }}">Read more >>></a>
-	</div>
-</div>
 </div>


### PR DESCRIPTION
This pull request introduces image processing and rendering across multiple configuration files and templates. The changes aim to improve responsiveness, optimize image quality, and provide fallback formats for better compatibility. It also refines the logic for handling featured images, post thumbnails, and lightbox functionality.

- Added new parameters in `config.toml` and `docs/config.toml` for responsive image sizes, resampling filters, fallback formats, and default image quality.
  
  ```toml
  [params.imgproc]
          enable = false
          # Default format for processed images
          format = "webp"
          # 0-100, image quality for compressed formats
          quality = 75
          # Image sizes for responsive images
          sizes = ["420", "789", "1019", "1430", "2048"]
          # Image resampling filter (Box, Lanczos, CatmullRom, MitchellNetravali, Linear, and NearestNeighbor)
          resamplingFilter = "Lanczos"
          # Default format for fallback images
          fallbackFormat = "jpg"
          # Default fallback image size
          fallbackSize = "789"
  ```
- Updated `layouts/_default/_markup/render-image.html` to include logic for responsive image sizes, fallback formats, and lazy loading.
- Enhanced `layouts/_default/single.html` to dynamically calculate image dimensions and generate responsive `srcset` attributes for featured images. Added support for lightbox integration.
- Modified `layouts/partials/post-card.html` to include responsive image handling for post card thumbnails.