### PR TITLE
Theme: Add @Gasiyu as a second author

### DIFF
--- a/docs/data/friends/gasiyu.yml
+++ b/docs/data/friends/gasiyu.yml
@@ -1,0 +1,9 @@
+id: gasiyu
+name: Gasiyu
+tagline: Jiābān Enthusiast (aka Coder)
+avatar:
+  kind: url
+  content: https://github.com/Gasiyu.png?size=75
+website: https://ngoding.id
+koukando: 95
+dead: false

--- a/theme.toml
+++ b/theme.toml
@@ -5,5 +5,7 @@ description = "MistY's OWN Hugo Theme"
 homepage = "https://github.com/lixk28/Alice"
 min_version = "0.20"
 
-[author]
-  name = "Xuekun Li"
+authors = [
+  { name = "Xuekun Li", homepage = "https://github.com/lixk28" },
+  { name = "Akbar Hamaminatu", homepage = "https://ngoding.id" }
+]


### PR DESCRIPTION
This pull request introduces a new contributor profile and updates the theme configuration to support multiple authors. 

- Added a new contributor profile for "Gasiyu" in `docs/data/friends/gasiyu.yml`.
- Updated `theme.toml` to replace the single `author` entry with a list of `authors`.

Close: #17 