### PR TITLE
Post: Implement jump to top/bottom button

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -77,5 +77,22 @@
 			{{- end -}}
 		{{- end -}}
 	</article>
+	
+	<!-- Jump to top/bottom buttons -->
+	<div class="jump-buttons">
+		<button id="jump-top" class="jump-btn jump-top" title="Jump to top">
+			<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7"/>
+			</svg>
+		</button>
+		<button id="jump-bottom" class="jump-btn jump-bottom" title="Jump to bottom">
+			<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/>
+			</svg>
+		</button>
+	</div>
+	
+	<!-- Jump buttons script -->
+	<script src="{{ "js/jumpButtons.js" | relURL }}"></script>
 </main>
 {{- end -}}

--- a/static/css/jump.css
+++ b/static/css/jump.css
@@ -1,0 +1,86 @@
+/* Jump to top/bottom buttons */
+.jump-buttons {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    z-index: 1000;
+}
+
+.jump-btn {
+    width: 50px;
+    height: 50px;
+    border: none;
+    border-radius: 50%;
+    background-color: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateX(100px);
+}
+
+.jump-btn.visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(0);
+}
+
+.jump-btn:hover {
+    background-color: white;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+    transform: translateX(0) scale(1.1);
+}
+
+.jump-btn svg {
+    width: 24px;
+    height: 24px;
+    stroke: #333;
+    stroke-width: 2;
+    transition: stroke 0.3s ease;
+}
+
+.jump-btn:hover svg {
+    stroke: #007acc;
+}
+
+/* Responsive design for smaller screens */
+@media (max-width: 768px) {
+    .jump-buttons {
+        right: 15px;
+        bottom: 15px;
+    }
+    
+    .jump-btn {
+        width: 40px;
+        height: 40px;
+    }
+    
+    .jump-btn svg {
+        width: 18px;
+        height: 18px;
+    }
+}
+
+@media (max-width: 480px) {
+    .jump-buttons {
+        right: 10px;
+        bottom: 10px;
+    }
+    
+    .jump-btn {
+        width: 35px;
+        height: 35px;
+    }
+    
+    .jump-btn svg {
+        width: 16px;
+        height: 16px;
+    }
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -21,6 +21,7 @@
 @import "dropcap.css";
 @import "taxo.css";
 @import "shell.css";
+@import "jump.css";
 
 * {
     box-sizing: border-box;

--- a/static/js/jumpButtons.js
+++ b/static/js/jumpButtons.js
@@ -1,0 +1,74 @@
+// Jump to top/bottom functionality
+document.addEventListener('DOMContentLoaded', function() {
+    const jumpTopBtn = document.getElementById('jump-top');
+    const jumpBottomBtn = document.getElementById('jump-bottom');
+    
+    if (!jumpTopBtn || !jumpBottomBtn) return;
+    
+    // Throttle function to limit scroll event frequency
+    function throttle(func, limit) {
+        let inThrottle;
+        return function() {
+            const args = arguments;
+            const context = this;
+            if (!inThrottle) {
+                func.apply(context, args);
+                inThrottle = true;
+                setTimeout(() => inThrottle = false, limit);
+            }
+        }
+    }
+    
+    // Show/hide buttons based on scroll position
+    function updateButtonVisibility() {
+        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+        const scrollHeight = document.documentElement.scrollHeight;
+        const clientHeight = document.documentElement.clientHeight;
+        const scrollPercentage = scrollTop / (scrollHeight - clientHeight);
+        
+        // Show buttons when user has scrolled down more than 200px
+        if (scrollTop > 200) {
+            jumpTopBtn.classList.add('visible');
+            jumpBottomBtn.classList.add('visible');
+        } else {
+            jumpTopBtn.classList.remove('visible');
+            jumpBottomBtn.classList.remove('visible');
+        }
+        
+        // Hide bottom button when near the bottom
+        if (scrollPercentage > 0.95) {
+            jumpBottomBtn.classList.remove('visible');
+        }
+        
+        // Hide top button when at the top
+        if (scrollTop < 100) {
+            jumpTopBtn.classList.remove('visible');
+        }
+    }
+    
+    // Smooth scroll to top
+    function scrollToTop() {
+        window.scrollTo({
+            top: 0,
+            behavior: 'smooth'
+        });
+    }
+    
+    // Smooth scroll to bottom
+    function scrollToBottom() {
+        window.scrollTo({
+            top: document.documentElement.scrollHeight,
+            behavior: 'smooth'
+        });
+    }
+    
+    // Event listeners
+    jumpTopBtn.addEventListener('click', scrollToTop);
+    jumpBottomBtn.addEventListener('click', scrollToBottom);
+    
+    // Throttled scroll event listener
+    window.addEventListener('scroll', throttle(updateButtonVisibility, 100));
+    
+    // Initial check
+    updateButtonVisibility();
+});


### PR DESCRIPTION
This pull request introduces a "jump to top/bottom" feature to improve navigation on post pages. It adds buttons to quickly scroll to the top or bottom of the page, along with the necessary styling and JavaScript functionality.

- Buttons appear after scrolling 200px down the page
- Buttons stick to the bottom-right corner of the viewport

**I only add basic styling. Need help to adapt to the theme style**

<img width="480" height="320" alt="Screen Shot 2025-07-22 at 21 13 05" src="https://github.com/user-attachments/assets/5a5a943f-c05c-4b96-b2fa-353b1f9a2261" />

Close: #20 