### PR TITLE
Add configurable storage type for tab persistence

### DIFF
--- a/assets/js/switchTab.js
+++ b/assets/js/switchTab.js
@@ -35,7 +35,7 @@ function persistTabChoices(tabGroup, tabIndex, storageType) {
     const key = window.location.origin + window.location.pathname + 'tab-choices';
     const val = storage.getItem(key) ?? "{}";
 
-    var tabChoices = JSON.parse(val);
+    const tabChoices = JSON.parse(val);
     tabChoices[tabGroup] = tabIndex;
     // console.log(key, tabChoices);
 
@@ -80,7 +80,5 @@ function switchTab(tabGroup, tabIndex) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    const storageType = "sessionStorage";
-    // const storageType = "localStorage";
-    resumeTabChoices(storageType);
+    resumeTabChoices("{{ site.Params.storage.type | default `sessionStorage` }}");
 });

--- a/config.toml
+++ b/config.toml
@@ -87,6 +87,10 @@
                     # Sort by {count | random}, default is count
                     sortBy = "count"
 
+    [params.storage]
+        # localStorage or sessionStorage
+        type = "sessionStorage"
+
     [params.codeblock]
         maxLinesOfCode = 64
 

--- a/layouts/_shortcodes/tabpanel.html
+++ b/layouts/_shortcodes/tabpanel.html
@@ -33,7 +33,7 @@
             data-tab-group="{{ $tabGroup }}"
             data-tab-index="{{ $tabIndex }}"
             onclick="switchTab('{{ $tabGroup }}', '{{ $tabIndex }}');
-                     persistTabChoices('{{ $tabGroup }}', '{{ $tabIndex }}', 'sessionStorage');">
+                     persistTabChoices('{{ $tabGroup }}', '{{ $tabIndex }}', '{{ site.Params.storage.type | default "sessionStorage" }}');">
             {{- $tab.Title | markdownify -}}
         </label>
     {{- end -}}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -25,7 +25,8 @@
 	{{- end -}}
 	{{- if .Params.tab -}}
 		{{- if .Params.tab.cursed -}}
-		<script src="{{ "js/switchTab.js" | relURL }}"></script>
+		{{- $switchTab := resources.Get "js/switchTab.js" | resources.ExecuteAsTemplate "js/switchTab.js" . -}}
+		<script src="{{ $switchTab.RelPermalink }}"></script>
 		{{- end -}}
 	{{- end -}}
 	{{- if .Params.lightbox -}}


### PR DESCRIPTION
- Introduce `params.storage.type` in config.toml with default as `sessionStorage`
- Update tab persistence logic to use configurable storage type
- Modify `baseof.html` to process `switchTab.js` with Hugo template

Closes: lixk28/Alice#45