### PR TITLE
Replace Permalink with RelPermalink

### DIFF
--- a/layouts/_partials/header.html
+++ b/layouts/_partials/header.html
@@ -28,14 +28,14 @@
 		{{- $blogoLink := (resources.Get .).RelPermalink -}}
 		{{- $logoTarget := site.Params.Header.LogoTarget | default "baseurl" -}}
 		{{- $isExternal := ne $logoTarget "baseurl" -}}
-		{{- $targetUrl := cond (eq $logoTarget "baseurl") site.BaseURL (cond (eq $logoTarget "imgurl") $blogoLink $logoTarget) -}}
+		{{- $targetUrl := cond (eq $logoTarget "baseurl") site.Home.RelPermalink (cond (eq $logoTarget "imgurl") $blogoLink $logoTarget) -}}
 		<a href="{{ $targetUrl }}" {{ if $isExternal }} target="_blank" {{ end }}>
 		    <img alt="blogo" src="{{ $blogoLink }}"/>
 		</a>
 	</div>
 	{{- end -}}
 	<div id="bio">
-		<h1 id="title"><a href="{{ .Site.BaseURL }}">{{ .Site.Params.Header.Title }}</a></h1>
+		<h1 id="title"><a href="{{ site.Home.RelPermalink }}">{{ .Site.Params.Header.Title }}</a></h1>
 		<h3 id="tagline">{{ .Site.Params.Header.Tagline }}</h3>
 	</div>
 	<nav id="menu">

--- a/layouts/_partials/post-card.html
+++ b/layouts/_partials/post-card.html
@@ -35,7 +35,7 @@
         {{- if site.Params.postcard.showDescription -}}
             <p class="post-description">{{ .Description | markdownify | safeHTML }}</p>
         {{- end -}}
-		<a class="post-read-more" href="{{ .Permalink }}">Read more >>></a>
+		<a class="post-read-more" href="{{ .RelPermalink }}">Read more >>></a>
 	</div>
 </div>
 </div>

--- a/layouts/_partials/sidebar/category-list.html
+++ b/layouts/_partials/sidebar/category-list.html
@@ -13,6 +13,6 @@
 {{ end }}
 
 {{ range $tags }}
-    <span><a href="{{ .page.Permalink }}">[{{ .page.Title }}]</a></span>
+    <span><a href="{{ .page.RelPermalink }}">[{{ .page.Title }}]</a></span>
     {{- $.args.delimiter | default "&emsp;" | safeHTML -}}
 {{ end }}

--- a/layouts/_partials/sidebar/tag-list.html
+++ b/layouts/_partials/sidebar/tag-list.html
@@ -13,6 +13,6 @@
 {{ end }}
 
 {{ range $tags }}
-    <span><a href="{{ .page.Permalink }}">#{{ .page.Title }}</a><sup> ({{ .count }})</sup></span>
+    <span><a href="{{ .page.RelPermalink }}">#{{ .page.Title }}</a><sup> ({{ .count }})</sup></span>
     {{- $.args.delimiter | default "&emsp;" | safeHTML -}}
 {{ end }}

--- a/layouts/tags/taxonomy.html
+++ b/layouts/tags/taxonomy.html
@@ -16,10 +16,10 @@
     {{ end }}
 
     {{ range ($orderedTaxo | shuffle) }}
-        <span class="tag bin-{{ index $binMap .Term }}"><a href="{{ .Page.Permalink }}">#{{ .Page.Title }}</a><sup> ({{ .Count }})</sup></span>&emsp;
+        <span class="tag bin-{{ index $binMap .Term }}"><a href="{{ .Page.RelPermalink }}">#{{ .Page.Title }}</a><sup> ({{ .Count }})</sup></span>&emsp;
     {{ end }}
     <!-- {{- range .Site.Taxonomies.tags -}}
-        <span><a href="{{ .Page.Permalink }}">#{{ .Page.Title }}</a><sup> ({{ .Count }})</sup></span>&emsp;
+        <span><a href="{{ .Page.RelPermalink }}">#{{ .Page.Title }}</a><sup> ({{ .Count }})</sup></span>&emsp;
     {{- end -}} -->
     </p>
 </main>


### PR DESCRIPTION
Problem:
Anchor links currently rely on the absolute site `BaseURL`. This causes navigation issues when accessing the site using a different host, as links redirect back to `localhost` or the configured domain.

Solution:
Use `RelPermalink` instead of absolute `Permalink` or `BaseURL`.

Benefit:
Improves compatibility across different deployment environments and ensures navigation works correctly regardless of the host address used to access the site.

Before (Header link pointed to localhost):
<img width="656" height="322" alt="image" src="https://github.com/user-attachments/assets/818c66a4-940f-4f11-8e30-ecb6738bcc05" />

After (Header link pointed to correct URL):
<img width="656" height="322" alt="image" src="https://github.com/user-attachments/assets/aa6543b0-57de-4ffe-b26b-b355f9de09c0" />
